### PR TITLE
Process default substrate errors in other way

### DIFF
--- a/lib/services/v2.0/error.dart
+++ b/lib/services/v2.0/error.dart
@@ -1,6 +1,8 @@
 class ChainError {
   String name;
-  String description;
+  String? description;
+
+  ChainError(this.name, this.description);
 
   ChainError.fromSubstrateMetadata(Map<String, dynamic> errorMetadata)
       : name = errorMetadata['name'],

--- a/lib/services/v2.0/kc2.dart
+++ b/lib/services/v2.0/kc2.dart
@@ -1055,6 +1055,12 @@ class KarmachainService implements K2ServiceInterface {
       return null;
     }
 
+    // Default substrate error decoded in other way by polkadart
+    if (failedReason['dispatch_error']?.value.runtimeType == String) {
+      // No way to provide additional description
+      return ChainError(failedReason['dispatch_error']?.value, null);
+    }
+
     final moduleIndex = failedReason['dispatch_error']?.value['index'];
     final errorIndex = failedReason['dispatch_error']?.value['error'][0];
     debugPrint('Process error module $moduleIndex error $errorIndex');
@@ -1068,7 +1074,7 @@ class KarmachainService implements K2ServiceInterface {
     debugPrint('Codec schema: $codecSchema');
 
     final errorMetadata =
-        codecSchema['type']['def'].value['variants'][errorIndex];
+    codecSchema['type']['def'].value['variants'][errorIndex];
     debugPrint('Error metadata: $errorMetadata');
 
     return ChainError.fromSubstrateMetadata(errorMetadata);


### PR DESCRIPTION
Polkadart decode default substrate errors in other way than error of custom pallets. In this case we unable to provide additional error description.