### PR TITLE
Fix leave pool test

### DIFF
--- a/lib/services/v2.0/nomination_pools/txs/withdraw_unbonded.dart
+++ b/lib/services/v2.0/nomination_pools/txs/withdraw_unbonded.dart
@@ -2,6 +2,7 @@ import 'package:karma_coin/services/v2.0/error.dart';
 import 'package:karma_coin/services/v2.0/event.dart';
 import 'package:karma_coin/services/v2.0/txs/tx.dart';
 import 'package:karma_coin/common_libs.dart';
+import 'package:ss58/ss58.dart' as ss58;
 
 // Withdraw all unbonded amount from the pool and leave it.
 // Can only be called once the unbound period has finished.
@@ -20,8 +21,10 @@ class KC2WithdrawUnbondedTxV1 extends KC2Tx {
       required List<KC2Event> txEvents,
       required int netId}) {
     try {
+      final memberAccount =
+          ss58.Codec(netId).encode(args['member_account'].value.cast<int>());
       return KC2WithdrawUnbondedTxV1(
-        memberAccount: args['member_account'],
+        memberAccount: memberAccount,
         args: args,
         signer: signer,
         chainError: chainError,

--- a/test/nomination_test.dart
+++ b/test/nomination_test.dart
@@ -332,12 +332,12 @@ void main() {
           expect(punchPoolMember, isNotNull);
           expect(punchPoolMember!.points, BigInt.zero);
 
-          // step 2 - wait 1 era and call widthdraw unbound
-          await Future.delayed(const Duration(seconds: 12));
-          debugPrint('Calling withdraw unbound...');
-          await kc2Service.withdrawUnbonded(punch.accountId);
+          // step 2 - wait 1 era and call withdraw unbound
           debugPrint('waiting 1 era...');
           await Future.delayed(const Duration(minutes: 3));
+          debugPrint('Calling withdraw unbound...');
+          await kc2Service.withdrawUnbonded(punch.accountId);
+          await Future.delayed(const Duration(seconds: 12));
           punchPoolMember = await kc2Service.getMembershipPool(punch.accountId);
           expect(punchPoolMember, isNull,
               reason: 'expected punch to be removed from pool');


### PR DESCRIPTION
Fix withdraw unbounded tx parsing.
Fix leave pool test: firstly wait for era pass and only after that call `withdrawUnbonded`